### PR TITLE
Fix compilation for 0.7.4 + A few more libclang function bindings

### DIFF
--- a/libs/clang/lib_clang.cr
+++ b/libs/clang/lib_clang.cr
@@ -105,5 +105,6 @@ lib LibClang
   fun get_argument = clang_Cursor_getArgument(Cursor, UInt32) : Cursor
   fun get_num_arg_types = clang_getNumArgTypes(Type) : Int32
   fun get_arg_type = clang_getArgType(Type, i : UInt32) : Type
+  fun get_result_type = clang_getResultType(Type) : Type
   fun get_enum_constant_decl_value = clang_getEnumConstantDeclValue(Cursor) : Int64
 end

--- a/libs/clang/lib_clang.cr
+++ b/libs/clang/lib_clang.cr
@@ -1,7 +1,9 @@
 require "./enums"
 
 @[Link("clang")]
+#@[Link(ldflags: "-L/usr/lib/llvm-3.6/lib/")] # Ubuntu 15.04
 @[Link(ldflags: "-L`xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/lib")]
+#@[Link(ldflags: "-Wl,-rpath /usr/lib/llvm-3.6/lib/")] # Ubuntu 15.04
 @[Link(ldflags: "-rpath `xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/lib")]
 lib LibClang
   type Index = Void*
@@ -99,4 +101,9 @@ lib LibClang
   fun get_token_kind = clang_getTokenKind(Token) : Clang::Token::Kind
   fun get_token_spelling = clang_getTokenSpelling(TranslationUnit, Token) : UInt8*
 
+  fun get_num_arguments = clang_Cursor_getNumArguments(Cursor) : Int32
+  fun get_argument = clang_Cursor_getArgument(Cursor, UInt32) : Cursor
+  fun get_num_arg_types = clang_getNumArgTypes(Type) : Int32
+  fun get_arg_type = clang_getArgType(Type, i : UInt32) : Type
+  fun get_enum_constant_decl_value = clang_getEnumConstantDeclValue(Cursor) : Int64
 end

--- a/src/crystal_lib.cr
+++ b/src/crystal_lib.cr
@@ -5,7 +5,7 @@ abstract class LibElementSpec
 end
 
 class ConstantsSpec < LibElementSpec
-  def initialize(json : Json::PullParser)
+  def initialize(json : JSON::PullParser)
     @remove_prefix = false
     prefix = nil
 
@@ -55,7 +55,7 @@ class LibSpec
   property libname
   property! imports
 
-  def initialize(json : Json::PullParser)
+  def initialize(json : JSON::PullParser)
     json.read_object do |key|
       case key
       when "input"


### PR DESCRIPTION
Not sure if you are planning to evolve this tool. I for sure like the idea! Was thinking about creating bindings for libflac, but that is tedious to do by hand :-)

This is obviously a small contribution, but I believe these functions will be needed to extract the information needed to generate the library module.

Not sure how to set the ldflags. clang doesn't seem to use pkg-config. Everything I tried so far seems to work fine with libclang 3.6 installed via apt-get on Ubuntu 15.04