### PR TITLE
Fix: compile LibClang on Linux

### DIFF
--- a/src/clang/lib_clang.cr
+++ b/src/clang/lib_clang.cr
@@ -1,8 +1,12 @@
 require "./enums"
 
 @[Link("clang")]
-@[Link(ldflags: "-L`xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/lib")]
-@[Link(ldflags: "-rpath `xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/lib")]
+ifdef darwin
+  @[Link(ldflags: "-L`xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/lib")]
+  @[Link(ldflags: "-rpath `xcode-select --print-path`/Toolchains/XcodeDefault.xctoolchain/usr/lib")]
+else
+  @[Link(ldflags: "`llvm-config-3.6 --ldflags 2>/dev/null || llvm-config-3.5 --ldflags 2>/dev/null || llvm-config --ldflags 2>/dev/null`")]
+end
 lib LibClang
   type Index = Void*
   type TranslationUnit = Void*


### PR DESCRIPTION
Rely on `llvm-config` on non-darwin targets.