### PR TITLE
Fix: crystal_type_name with screaming constants

### DIFF
--- a/spec/headers/simple.h
+++ b/spec/headers/simple.h
@@ -45,6 +45,12 @@ enum some_enum_2 {
 };
 enum some_enum_2 just_some_enum_2();
 
+enum some_enum_3 {
+  node_para = 1,
+  NODE_LINK = 2
+};
+enum some_enum_3 just_some_enum_3();
+
 typedef struct { int x; } some_struct_1;
 some_struct_1 just_some_struct_1();
 

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -109,6 +109,15 @@ describe LibBodyTransformer do
     )
 
   assert_transform "simple",
+                   "fun just_some_enum_3", %(
+      enum SomeEnum3
+        NodePara = 1
+        NodeLink = 2
+      end
+      fun just_some_enum_3 : SomeEnum3
+    )
+
+  assert_transform "simple",
                    "fun just_some_struct_1", %(
       struct SomeStruct1
         x : LibC::Int

--- a/src/crystal_lib/type_mapper.cr
+++ b/src/crystal_lib/type_mapper.cr
@@ -205,7 +205,7 @@ class CrystalLib::TypeMapper
       name = name[underscore_index + 1..-1]
     end
 
-    name = name.camelcase
+    name = name.downcase.camelcase
 
     if underscore_index
       name = String.build do |str|


### PR DESCRIPTION
I noticed C enums containing screaming constants like `NODE_ELEMENT` were transformed as `NODEELEMENT` instead of `NodeElement`. This affects any C type name transformed to a Crystal type.

The real culprit is `String#camelcase`. I checked Rails' ActiveSupport behavior, but it would transform to `NODEElement` which would be as weird (unexpected?). I'm not exactly sure how that should be fixed, but here is a proposed solution.