### PR TITLE
Some parse fixes

### DIFF
--- a/spec/headers/simple.h
+++ b/spec/headers/simple.h
@@ -117,3 +117,6 @@ typedef struct {
 } struct_with_nest_2;
 
 void just_some_struct_with_nest_2(struct_with_nest_2* handle);
+
+#define inet_pton __inet_pton
+int __inet_pton(int, char*, void*);

--- a/spec/headers/simple.h
+++ b/spec/headers/simple.h
@@ -120,3 +120,6 @@ void just_some_struct_with_nest_2(struct_with_nest_2* handle);
 
 #define inet_pton __inet_pton
 int __inet_pton(int, char*, void*);
+
+#define OCTAL 0755
+#define HEXA 0xffff

--- a/spec/headers/simple.h
+++ b/spec/headers/simple.h
@@ -52,6 +52,13 @@ enum some_enum_3 {
 };
 enum some_enum_3 just_some_enum_3();
 
+enum {
+  SOCK_STREAM = 1,
+  #define SOCK_STREAM SOCK_STREAM
+  SOCK_DGRAM = 2,
+  #define SOCK_DGRAM SOCK_DGRAM
+};
+
 typedef struct { int x; } some_struct_1;
 some_struct_1 just_some_struct_1();
 

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -119,11 +119,18 @@ describe LibBodyTransformer do
     )
 
   assert_transform "simple",
-    "fun just_some_struct_1", %(
-      struct SomeStruct1
-        x : LibC::Int
+    "fun just_some_enum_3", %(
+      enum SomeEnum3
+        NodePara = 1
+        NodeLink = 2
       end
-      fun just_some_struct_1 : SomeStruct1
+      fun just_some_enum_3 : SomeEnum3
+    )
+
+  assert_transform "simple",
+    "SOCK_STREAM = SOCK_STREAM\nSOCK_DGRAM = SOCK_DGRAM", %(
+      SOCK_STREAM = 1
+      SOCK_DGRAM = 2
     )
 
   assert_transform "simple",

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -221,4 +221,9 @@ describe LibBodyTransformer do
 
       fun just_some_struct_with_nest_2(handle : StructWithNest2*)
     )
+
+  assert_transform "simple",
+    "fun inet_pton", %(
+      fun inet_pton(x0 : LibC::Int, x1 : LibC::Char*, x2 : Void*) : LibC::Int
+    )
 end

--- a/spec/lib_body_transformer_spec.cr
+++ b/spec/lib_body_transformer_spec.cr
@@ -226,4 +226,10 @@ describe LibBodyTransformer do
     "fun inet_pton", %(
       fun inet_pton(x0 : LibC::Int, x1 : LibC::Char*, x2 : Void*) : LibC::Int
     )
+
+  assert_transform "simple",
+    "OCTAL = OCTAL; HEXA = HEXA", %(
+      OCTAL = 493
+      HEXA = 65535
+    )
 end

--- a/src/crystal_lib/lib_body_transformer.cr
+++ b/src/crystal_lib/lib_body_transformer.cr
@@ -12,6 +12,11 @@ class CrystalLib::LibBodyTransformer < Crystal::Transformer
   def transform(node : Crystal::FunDef)
     name = node.real_name
     func = find_node name
+
+    while func.is_a?(CrystalLib::Define)
+      func = find_node(func.value)
+    end
+
     raise "can't find function #{name}" unless func.is_a?(CrystalLib::Function)
 
     node.args = func.args.map_with_index do |arg, i|

--- a/src/crystal_lib/lib_body_transformer.cr
+++ b/src/crystal_lib/lib_body_transformer.cr
@@ -46,6 +46,10 @@ class CrystalLib::LibBodyTransformer < Crystal::Transformer
       end
     end
 
+    if value.size > 1 && value[0] == '0' && value[1] != 'x'
+      value = "0o#{value[1 .. -1]}"
+    end
+
     begin
       node.value = Crystal::Parser.parse(value)
     rescue ex : Crystal::Exception


### PR DESCRIPTION
Here are some fixes for #15 and #16.

I'm not sure about 57f3e64 and maybe the problem should be fixed in the same manner than 572f2d30582ac880e725119cf3e16c4f6bd821c1 (nested typedef structs): memoize defines until an enum is visited, then change their values once the enum is parsed?